### PR TITLE
Fix yt-dlp cookie option

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -49,7 +49,6 @@ def analyze(url):
         if os.path.isfile(cookie_path):
             opts['cookiefile'] = cookie_path
     ydl = YoutubeDL(opts)
-    ydl = YoutubeDL({'quiet': True})
     info = ydl.extract_info(url, download=False)
     stream_url = info['url']
 

--- a/app.py
+++ b/app.py
@@ -141,7 +141,6 @@ def detect_stream(url, safe):
         if os.path.isfile(cookie_path):
             opts['cookiefile'] = cookie_path
     ydl = YoutubeDL(opts)
-    ydl = YoutubeDL({'quiet': True})
     try:
         info = ydl.extract_info(url, download=False)
     except Exception as e:


### PR DESCRIPTION
## Summary
- use configured cookie file when extracting streams

## Testing
- `python -m py_compile analyze.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_68451c7b0174833391dc7e71d29e9e12