### PR TITLE
Improve config validation and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
 
 일반 녹화물은 `recordings/` 폴더에,
 말 감지 시 저장되는 증거 영상은 `evidence/` 폴더에 구분되어 저장됩니다.
+이 위치는 `config.json`의 `evidence_folder` 값으로 변경할 수 있습니다.
 
 ## 수동 분석
 
@@ -49,7 +50,9 @@ python analyze.py <youtube_url>
 ## 쿠키 파일 설정
 
 로그인이 필요한 영상의 경우 브라우저에서 추출한 쿠키 파일을
-`config.json`의 `"cookiefile"` 항목에 지정하면 접근할 수 있습니다.
+`config.json`의 `"cookiefile"` 항목에 지정하면 접근할 수 있습니다. 쿠키는
+반드시 Netscape 형식으로 저장해야 하며, 지정한 경로에 실제 파일이 존재해야
+합니다.
 
 ```
 {
@@ -57,7 +60,17 @@ python analyze.py <youtube_url>
 }
 ```
 
-쿠키 파일을 저장한 뒤 같은 경로에 두고 실행하면 됩니다.
+쿠키 파일을 찾을 수 없으면 프로그램이 즉시 종료되므로 경로를 정확히
+확인하십시오.
+
+쿠키는 [cookies.txt](https://github.com/dragonofmercy/cookies.txt)와 같은
+브라우저 확장으로 내보내는 것이 가장 간편합니다. 확장 설치 후 유튜브에
+로그인한 탭에서 "Export"를 눌러 `cookies.txt` 파일을 저장하면 됩니다.
+
+## ffmpeg 설정
+
+기본값으로 `ffmpeg` 실행 파일을 사용합니다. Windows 사용자는
+`config.json`의 `"ffmpeg_exe"` 값을 `"ffmpeg.exe"`로 변경해야 합니다.
 
 
 ## 시스템 플로우

--- a/analyze.py
+++ b/analyze.py
@@ -16,6 +16,14 @@ DETECT_MODEL = os.path.join(BASE_DIR, cfg.get('detect_model', 'yolov5s.pt'))
 CONF_THRESHOLD = float(cfg.get('conf_threshold', 0.5))
 EVIDENCE_ROOT = os.path.join(BASE_DIR, cfg.get('evidence_folder', 'evidence'))
 COOKIEFILE = cfg.get('cookiefile')
+COOKIE_PATH = None
+if COOKIEFILE:
+    _cp = os.path.join(BASE_DIR, COOKIEFILE)
+    if os.path.isfile(_cp):
+        COOKIE_PATH = _cp
+    else:
+        print(f'[오류] 쿠키 파일을 찾을 수 없습니다: {_cp}')
+        sys.exit(1)
 
 
 def load_detector():
@@ -44,13 +52,16 @@ def create_writer(folder, base, fps, width, height):
 
 def analyze(url):
     opts = {'quiet': True}
-    if COOKIEFILE:
-        cookie_path = os.path.join(BASE_DIR, COOKIEFILE)
-        if os.path.isfile(cookie_path):
-            opts['cookiefile'] = cookie_path
+    if COOKIE_PATH:
+        opts['cookiefile'] = COOKIE_PATH
     ydl = YoutubeDL(opts)
-    ydl = YoutubeDL({'quiet': True})
-    info = ydl.extract_info(url, download=False)
+    try:
+        info = ydl.extract_info(url, download=False)
+    except Exception as e:
+        print(f'[오류] 동영상 정보를 가져오지 못했습니다: {e}')
+        if COOKIE_PATH:
+            print('[안내] 쿠키 파일이 올바른지 확인하세요. Netscape 형식으로 최신 쿠키를 내보내야 합니다.')
+        return
     stream_url = info['url']
 
     cap = cv2.VideoCapture(stream_url)

--- a/app.py
+++ b/app.py
@@ -9,6 +9,7 @@ import subprocess
 import threading
 import time
 import signal
+import shutil
 from datetime import timedelta
 
 try:
@@ -29,16 +30,27 @@ CHANNEL_URLS = cfg.get("channels", [])
 CHECK_INTERVAL = cfg.get("check_interval", 60)
 OUTPUT_ROOT = os.path.join(BASE_DIR, cfg.get("output_folder", "recordings"))
 EVIDENCE_ROOT = os.path.join(BASE_DIR, cfg.get("evidence_folder", "evidence"))
-FFMPEG_EXE_NAME = cfg.get("ffmpeg_exe", "ffmpeg.exe")
+FFMPEG_EXE_NAME = cfg.get("ffmpeg_exe", "ffmpeg")
 DETECT_MODEL = os.path.join(BASE_DIR, cfg.get("detect_model", "yolov5s.pt"))
 CONF_THRESHOLD = float(cfg.get("conf_threshold", 0.5))
 COOKIEFILE = cfg.get("cookiefile")
+COOKIE_PATH = None
+if COOKIEFILE:
+    _cp = os.path.join(BASE_DIR, COOKIEFILE)
+    if os.path.isfile(_cp):
+        COOKIE_PATH = _cp
+    else:
+        print(f"[오류] 쿠키 파일을 찾을 수 없습니다: {_cp}")
+        sys.exit(1)
 LOG_MAX_SIZE = 10 * 1024 * 1024  # 10 MB per log file
 # Logs from yt_dlp are stored as OUTPUT_ROOT/<channel>.log
 
-ffmpeg_path = os.path.join(BASE_DIR, FFMPEG_EXE_NAME)
+ffmpeg_path = shutil.which(FFMPEG_EXE_NAME)
+if not ffmpeg_path:
+    ffmpeg_path = os.path.join(BASE_DIR, FFMPEG_EXE_NAME)
 if not os.path.isfile(ffmpeg_path):
-    print(f"[오류] ffmpeg.exe를 찾을 수 없습니다: {ffmpeg_path}")
+    print(f"[오류] ffmpeg 실행 파일을 찾을 수 없습니다: {FFMPEG_EXE_NAME}")
+    print("config.json의 ffmpeg_exe 값을 확인하세요.")
     sys.exit(1)
 
 stop_flag = False
@@ -91,10 +103,8 @@ def start_recording(url):
         "-o", template,
         url
     ]
-    if COOKIEFILE:
-        cookie_path = os.path.join(BASE_DIR, COOKIEFILE)
-        if os.path.isfile(cookie_path):
-            cmd.extend(["--cookies", cookie_path])
+    if COOKIE_PATH:
+        cmd.extend(["--cookies", COOKIE_PATH])
     proc = subprocess.Popen(cmd, stdout=log_file, stderr=subprocess.STDOUT)
     proc.log_file = log_file  # store to close later
     start_times[url] = time.time()
@@ -136,16 +146,15 @@ def create_evidence_writer(folder, base_name, fps, width, height):
 def detect_stream(url, safe):
     global detector
     opts = {'quiet': True}
-    if COOKIEFILE:
-        cookie_path = os.path.join(BASE_DIR, COOKIEFILE)
-        if os.path.isfile(cookie_path):
-            opts['cookiefile'] = cookie_path
+    if COOKIE_PATH:
+        opts['cookiefile'] = COOKIE_PATH
     ydl = YoutubeDL(opts)
-    ydl = YoutubeDL({'quiet': True})
     try:
         info = ydl.extract_info(url, download=False)
     except Exception as e:
         print(f"[오류] 스트림 정보를 가져올 수 없습니다: {e}")
+        if COOKIE_PATH:
+            print("[안내] 쿠키 파일이 올바른지 확인하세요. Netscape 형식으로 최신 쿠키를 내보내야 합니다.")
         return
     stream_url = info.get('url')
     cap = cv2.VideoCapture(stream_url)

--- a/config.json
+++ b/config.json
@@ -24,10 +24,9 @@
   ],
   "check_interval": 30,
   "output_folder": "recordings",
-  "ffmpeg_exe": "ffmpeg.exe",
+  "ffmpeg_exe": "ffmpeg",
   "detect_model": "yolov5s.pt",
   "conf_threshold": 0.5,
-  "evidence_folder": "evidence",
-  "cookiefile": "cookies.txt"
+  "cookiefile": "cookies.txt",
   "evidence_folder": "evidence"
 }


### PR DESCRIPTION
## Summary
- verify cookie file exists in `analyze.py` and `app.py`
- remove duplicate key from `config.json`
- default to `ffmpeg` executable for portability
- document cookie format and ffmpeg path in README
- show clear hints when extracting info fails

## Testing
- `python -m py_compile analyze.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_68451c7b0174833391dc7e71d29e9e12